### PR TITLE
Bug - Ensure flights and hotels share same location

### DIFF
--- a/HolidaySearch.Tests/Data/flight-data.json
+++ b/HolidaySearch.Tests/Data/flight-data.json
@@ -16,6 +16,14 @@
     "departure_date": "2023-07-01"
   },
   {
+    "id": 13,
+    "airline": "Trans American Airlines",
+    "from": "MAN",
+    "to": "PMI",
+    "price": 170,
+    "departure_date": "2023-07-01"
+  },
+  {
     "id": 3,
     "airline": "Trans American Airlines",
     "from": "MAN",

--- a/HolidaySearch.Tests/Data/hotel-data.json
+++ b/HolidaySearch.Tests/Data/hotel-data.json
@@ -94,7 +94,14 @@
     "arrival_date": "2023-07-01",
     "price_per_night": 45,
     "local_airports": [ "AGP" ],
-
+    "nights": 14
+  },
+  {
+    "id": 14,
+    "name": "Sol Katmandu Park & Resort",
+    "arrival_date": "2023-07-01",
+    "price_per_night": 60,
+    "local_airports": [ "PMI" ],
     "nights": 14
   },
   {

--- a/HolidaySearch.Tests/HolidaySearchTests.cs
+++ b/HolidaySearch.Tests/HolidaySearchTests.cs
@@ -47,6 +47,15 @@ namespace HolidaySearch.Tests
             Assert.That(results.First().Flight.Id, Is.EqualTo(7));
             Assert.That(results.First().Hotel.Id, Is.EqualTo(6));
         }
+
+        [Test]
+        public void Only_maps_hotels_and_flights_with_matching_destination_codes()
+        {
+            var query = new HolidaySearchQuery([], ["AGP", "PMI"], new DateOnly(2023, 07, 01), 14);
+
+            var results = _subject.SearchHolidays(query);
+            Assert.That(results.All(x => x.Hotel.LocalAirports.Contains(x.Flight.To)));
+        }
         
         private static IEnumerable<FlightData> SeedFlightData()
         {

--- a/HolidaySearch/HolidaySearch.cs
+++ b/HolidaySearch/HolidaySearch.cs
@@ -31,7 +31,7 @@ namespace HolidaySearch
 
         public IEnumerable<HolidaySearchResult> CreatePackageHolidaySearchResults(IEnumerable<HotelData> hotels, IEnumerable<FlightData> flights)
         {
-            return hotels.SelectMany(hotel => flights,
+            return hotels.SelectMany(hotel => flights.Where(flight => hotel.LocalAirports.Contains(flight.To)),
                 (hotel, flight) => new HolidaySearchResult(flight, hotel))
                 .OrderBy(package => package.Flight.Price + package.Hotel.PricePerNight)
                 .ToList();


### PR DESCRIPTION
### What?

Each hotel result would be mapped to each flight result. Because we allow multiple possible destinations in the search query, hotels and flights would be returned as packages when corresponding to different holiday destinations.

### Fix

Only map hotels and flights that share a location, utilising a Where clause in the Select